### PR TITLE
Making runner's CommandLinePlayerAgent public.

### DIFF
--- a/runner/src/main/java/com/codingame/gameengine/runner/CommandLinePlayerAgent.java
+++ b/runner/src/main/java/com/codingame/gameengine/runner/CommandLinePlayerAgent.java
@@ -5,7 +5,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Properties;
 
-class CommandLinePlayerAgent extends Agent {
+public class CommandLinePlayerAgent extends Agent {
 
     private OutputStream processStdin;
     private InputStream processStdout;


### PR DESCRIPTION
Signed-off-by: LSmith-Zenoscave <lsmith@zenoscave.com>

JavaPlayerAgent is public.  This should be consistent, I believe. 
Makes using the SDK slightly easier for developers