### PR TITLE
Extracted GameRunner.bootstrapPlayersWait.

### DIFF
--- a/runner/src/main/java/com/codingame/gameengine/runner/GameRunner.java
+++ b/runner/src/main/java/com/codingame/gameengine/runner/GameRunner.java
@@ -95,10 +95,7 @@ abstract class GameRunner {
             throw new RuntimeException("Bootstrap of all players failed to bootsrap");
         }
 
-        try {
-            Thread.sleep(300); // Arbitrary time to wait for bootstrap
-        } catch (InterruptedException e) {
-        }
+        bootstrapPlayersWait();
 
         for (Agent agent : players) {
             BlockingQueue<String> queue = new ArrayBlockingQueue<>(1024);
@@ -106,6 +103,14 @@ abstract class GameRunner {
             writers.add(asyncWriter);
             queues.add(queue);
             asyncWriter.start();
+        }
+    }
+
+    protected void bootstrapPlayersWait() {
+        try {
+            // Arbitrary time to wait for bootstrap
+            Thread.sleep(300);
+        } catch (InterruptedException e) {
         }
     }
 


### PR DESCRIPTION
In most cases, this delay can be reduced (even to 0), or there can be a way to really wait for _something_. In my tests, where only CLI agents were used, reducing this to 0 (or even not sleeping at all) caused no problems and reduced evaluation time.