### PR TITLE
Fix ZipSlip bug found by LGTM.com

### DIFF
--- a/runner/src/main/java/com/codingame/gameengine/runner/Renderer.java
+++ b/runner/src/main/java/com/codingame/gameengine/runner/Renderer.java
@@ -139,6 +139,9 @@ class Renderer {
                     String entryTail = name.substring(sourceFolder.length());
 
                     File f = new File(targetFolder + File.separator + entryTail);
+                    if (!f.toPath().normalize().startsWith(targetFolder)) {
+                        throw new IOException("Zip entry contained path traversal");
+                    }
                     if (entry.isDirectory()) {
                         f.mkdir();
                     } else {


### PR DESCRIPTION
The unsanitized path of a zip archive entry, which may contain `..`, was used directly to resolve the destination path for the files being unzipped.

Although the prefix of the path was checked against `sourceFolder`, there could be `..` path segments after that.

Extracting files from a malicious archive without validating that the destination file path is within the destination directory can cause files outside the destination directory to be overwritten.

There are a [bunch of other alerts](https://lgtm.com/projects/g/CodinGame/codingame-game-engine/alerts/) for this project on LGTM.com that would probably be good to fix too.

*(Full disclosure: I'm part of the team behind LGTM.com)*