### PR TITLE
reduce replay size when using the ToggleModule

### DIFF
--- a/engine/modules/toggle/src/main/java/com/codingame/gameengine/module/toggle/ToggleModule.java
+++ b/engine/modules/toggle/src/main/java/com/codingame/gameengine/module/toggle/ToggleModule.java
@@ -13,9 +13,9 @@ import com.google.inject.Singleton;
 
 /**
  * @author Jean Porée
- * 
+ *
  *         This module allows you to display or hide elements of the GraphicEntityModule using the viewer's options menu.
- * 
+ *
  */
 @Singleton
 public class ToggleModule implements Module {
@@ -70,14 +70,19 @@ public class ToggleModule implements Module {
     public void onAfterOnEnd() {}
 
     private void sendFrameData() {
-        Object[] data = { newRegistration };
+        HashMap<String, String> data = new HashMap<>();
+        for (int d : newRegistration.keySet()) {
+            String key = newRegistration.get(d).name;
+            if (!data.containsKey(key)) data.put(key, "");
+            data.put(key, data.get(key) + d + (newRegistration.get(d).state ? "+" : "-"));
+        }
         gameManager.setViewData("toggles", data);
 
         newRegistration.clear();
     }
     /**
      * Will display the entity only when the toggle state matches the state you set
-     * 
+     *
      * @param entity which will be displayed
      * @param toggle the name of the toggle you want to use
      * @param state the state of the toggle where the entity will be displayed at

--- a/engine/modules/toggle/src/main/java/com/codingame/gameengine/module/toggle/ToggleModule.java
+++ b/engine/modules/toggle/src/main/java/com/codingame/gameengine/module/toggle/ToggleModule.java
@@ -76,7 +76,8 @@ public class ToggleModule implements Module {
             if (!data.containsKey(key)) data.put(key, "");
             data.put(key, data.get(key) + d + (newRegistration.get(d).state ? "+" : "-"));
         }
-        gameManager.setViewData("toggles", data);
+        if (newRegistration.size() > 0)
+            gameManager.setViewData("toggles", data);
 
         newRegistration.clear();
     }

--- a/engine/modules/toggle/src/main/resources/view/toggle-module/ToggleModule.js
+++ b/engine/modules/toggle/src/main/resources/view/toggle-module/ToggleModule.js
@@ -58,7 +58,14 @@ export class ToggleModule {
     if (!data) {
       return
     }
-    const newRegistration = data[0]
+    var newRegistration = {}
+    Object.entries(data).forEach(([key, value]) => {
+        value.match(/\d+./g).forEach(m => {
+            var entityId = m.slice(0, -1)
+            var state = m.slice(-1) === "+"
+            newRegistration[entityId] = {"name":key, "state":state}
+        })
+    })
     const registered = { ...this.previousFrame.registered, ...newRegistration }
     const frame = { registered, number: frameInfo.number }
     this.previousFrame = frame

--- a/engine/modules/toggle/src/main/resources/view/toggle-module/ToggleModule.js
+++ b/engine/modules/toggle/src/main/resources/view/toggle-module/ToggleModule.js
@@ -55,17 +55,16 @@ export class ToggleModule {
   }
 
   handleFrameData (frameInfo, data) {
-    if (!data) {
-      return
-    }
     var newRegistration = {}
-    Object.entries(data).forEach(([key, value]) => {
-        value.match(/\d+./g).forEach(m => {
-            var entityId = m.slice(0, -1)
-            var state = m.slice(-1) === "+"
-            newRegistration[entityId] = {"name":key, "state":state}
+    if (data) {
+        Object.entries(data).forEach(([key, value]) => {
+            value.match(/\d+./g).forEach(m => {
+                var entityId = m.slice(0, -1)
+                var state = m.slice(-1) === "+"
+                newRegistration[entityId] = {"name":key, "state":state}
+            })
         })
-    })
+    }
     const registered = { ...this.previousFrame.registered, ...newRegistration }
     const frame = { registered, number: frameInfo.number }
     this.previousFrame = frame


### PR DESCRIPTION
Right now the ToggleModule increases the replay size a lot when creating a debug view, e.g.
`\"toggles\":[{\"2\":{\"name\":\"d\",\"state\":false},\"3\":{\"name\":\"d\",\"state\":true},\"4\":{\"name\":\"d\",\"state\":false},\"9\":{\"name\":\"d\",\"state\":true},\"10\":{\"name\":\"d\",\"state\":false},\"13\":{\"name\":\"d\",\"state\":true},\"14\":{\"name\":\"d\",\"state\":false}}]
`
This pull request stores the same information more efficiently:
`\"toggles\":{\"d\":\"2-3+4-9+10-13+14-\"}`