### PR TITLE
Fixed 2 bugs with the camera module

### DIFF
--- a/engine/community-modules/camera/src/main/resources/view/camera-module/CameraModule.js
+++ b/engine/community-modules/camera/src/main/resources/view/camera-module/CameraModule.js
@@ -4,7 +4,7 @@ import {easeOut} from '../core/transitions.js'
 import {lerpPosition} from '../core/utils.js'
 
 export class CameraModule {
-    constructor(assets) {
+    constructor(_assets) {
         CameraModule.instance = this
         this.container = {id: -1, sizeX: -1, sizeY: -1}
         this.cameraOffset = 0
@@ -19,7 +19,6 @@ export class CameraModule {
         this.oldCameraState = {scale: {x: -1, y: -1}, position: {x: 0, y: 0}}
         this.currentCameraState = {scale: {x: -1, y: -1}, position: {x: 0, y: 0}}
         this.previousUpdateData = this.currentUpdateFrame = this.currentUpdateProgress = undefined
-        this.viewerActive = true
         this.active = true
 
     }
@@ -28,11 +27,12 @@ export class CameraModule {
         return 'c'
     }
 
-    setActive(active) {
-        this.viewerActive = active
-        this.lastFrame = -2
-        if (this.previousUpdateData !== undefined) {
-            this.updateScene(this.previousUpdateData, this.currentUpdateFrame, this.currentUpdateProgress || 1)
+    static setActive(active) {
+        CameraModule.viewerActive = active
+        const module = CameraModule.instance
+        module.lastFrame = -2
+        if (module.previousUpdateData !== undefined) {
+            module.updateScene(module.previousUpdateData, module.currentUpdateFrame, module.currentUpdateProgress || 1)
         }
     }
 
@@ -59,7 +59,7 @@ export class CameraModule {
         this.currentUpdateProgress = progress
         this.previousUpdateData = previousData
         const isActive = (currentData.registered.size !== 0) && (currentData.container.entity !== null)
-        if (!(currentData.active && this.viewerActive)) {
+        if (!(currentData.active && CameraModule.viewerActive)) {
             if (isActive) {
                 currentData.container.entity.graphics.scale = {x: 1, y: 1}
                 currentData.container.entity.graphics.position = {x: 0, y: 0}
@@ -170,11 +170,8 @@ export class CameraModule {
     }
 
     reinitScene() {
-        if (this.currentUpdateProgress !== undefined) {
-            this.lastFrame = -2
-            this.updateScene(this.previousUpdateData, this.currentUpdateFrame, 1)
-        }
-
     }
 
 }
+
+CameraModule.viewerActive = true

--- a/engine/community-modules/camera/src/main/resources/view/camera-module/CameraToggleModule.js
+++ b/engine/community-modules/camera/src/main/resources/view/camera-module/CameraToggleModule.js
@@ -4,16 +4,16 @@ import { DuplicateToggleValueError } from "./errors/DuplicateToggleValueError.js
 
 export class CameraToggleModule {
 
-    constructor(assets) {
+    constructor(_assets) {
         this.previousFrame = {}
         this.missingToggles = {}
         this.d = false
         CameraToggleModule.refreshContent = () => {
             this.d = !this.d
             if (CameraToggleModule.toggles.cameraMode) {
-                CameraModule.instance.setActive(true)
+                CameraModule.setActive(true)
             } else {
-                CameraModule.instance.setActive(false)
+                CameraModule.setActive(false)
             }
         }
         pushDuplicateErrors()
@@ -51,7 +51,7 @@ export class CameraToggleModule {
     handleFrameData(frameInfo, data) {
     }
 
-    reinitScene(container, canvasData) {
+    reinitScene(_container, _canvasData) {
         CameraToggleModule.refreshContent()
     }
 }


### PR DESCRIPTION
- Starting state of the camera toggle was ignored depending on the order in which the modules were loaded.
- When resizing the player, the camera would zoom way too much