### PR TITLE
add soft-timeout

### DIFF
--- a/engine/core/src/main/java/com/codingame/gameengine/core/AbstractPlayer.java
+++ b/engine/core/src/main/java/com/codingame/gameengine/core/AbstractPlayer.java
@@ -28,10 +28,14 @@ abstract public class AbstractPlayer {
     private List<String> inputs = new ArrayList<>();
     private List<String> outputs;
     private boolean timeout;
+    private int timelimit;
     private int score;
     private boolean hasBeenExecuted;
     private boolean hasNeverBeenExecuted = true;
     private long lastExecutionTimeMs = -1;
+    private int timelimitsExceeded = 0;
+    private boolean timelimitExceededLastTurn = false;
+    private final int MAX_SOFT_TIMELIMIT_EXCEEDS = 2;
 
     /**
      * Returns a string that will be converted into the real nickname by the viewer.
@@ -79,6 +83,10 @@ abstract public class AbstractPlayer {
         this.score = score;
     }
 
+    void setTimelimit(int timelimit) {
+        this.timelimit = timelimit;
+    }
+
     /**
      * Adds a new line to the input to send to the player on execute.
      * 
@@ -102,6 +110,9 @@ abstract public class AbstractPlayer {
         gameManagerProvider.get().execute(this);
         this.hasBeenExecuted = true;
         this.hasNeverBeenExecuted = false;
+        this.timelimitExceededLastTurn = getLastExectionTimeMs() > this.timelimit;
+        if (this.timelimitExceededLastTurn) this.timelimitsExceeded++;
+        if (this.timelimitsExceeded > MAX_SOFT_TIMELIMIT_EXCEEDS) this.timeout = true;
     }
 
     /**
@@ -182,5 +193,13 @@ abstract public class AbstractPlayer {
     
     public long getLastExectionTimeMs() {
         return lastExecutionTimeMs;
+    }
+
+    public int getTimelimitsExceeded() {
+        return timelimitsExceeded;
+    }
+
+    public boolean hasTimelimitExceededLastTurn() {
+        return timelimitExceededLastTurn;
     }
 }

--- a/engine/core/src/main/java/com/codingame/gameengine/core/AbstractPlayer.java
+++ b/engine/core/src/main/java/com/codingame/gameengine/core/AbstractPlayer.java
@@ -34,6 +34,8 @@ abstract public class AbstractPlayer {
     private boolean hasNeverBeenExecuted = true;
     private long lastExecutionTimeMs = -1;
     private int timelimitsExceeded = 0;
+    private  boolean useTimebank = false;
+    private int timebank = 0;
     private boolean timelimitExceededLastTurn = false;
     private final int MAX_SOFT_TIMELIMIT_EXCEEDS = 2;
 
@@ -83,8 +85,34 @@ abstract public class AbstractPlayer {
         this.score = score;
     }
 
+    /**
+     * Set the player's time limit for the next turn
+     *
+     * @param timelimit
+     *            The time limit in milliseconds
+     */
     void setTimelimit(int timelimit) {
         this.timelimit = timelimit;
+    }
+
+    /**
+     * Set the player's timebank for the whole game
+     *
+     * @param timebank
+     *            the timebank in milliseconds
+     */
+    void setTimebank(int timebank) {
+        this.useTimebank = true;
+        this.timebank = timebank;
+    }
+
+    /**
+     * Get the remaining timebank
+     *
+     * @return the remaining timebank in milliseconds
+     */
+    public int getRemainingTimebank() {
+        return timebank;
     }
 
     /**
@@ -110,6 +138,7 @@ abstract public class AbstractPlayer {
         gameManagerProvider.get().execute(this);
         this.hasBeenExecuted = true;
         this.hasNeverBeenExecuted = false;
+        if (this.useTimebank) this.timebank -= getLastExectionTimeMs();
         this.timelimitExceededLastTurn = getLastExectionTimeMs() > this.timelimit;
         if (this.timelimitExceededLastTurn) this.timelimitsExceeded++;
         if (this.timelimitsExceeded > MAX_SOFT_TIMELIMIT_EXCEEDS) this.timeout = true;

--- a/engine/core/src/main/java/com/codingame/gameengine/core/AbstractPlayer.java
+++ b/engine/core/src/main/java/com/codingame/gameengine/core/AbstractPlayer.java
@@ -34,7 +34,7 @@ abstract public class AbstractPlayer {
     private boolean hasNeverBeenExecuted = true;
     private long lastExecutionTimeMs = -1;
     private int timelimitsExceeded = 0;
-    private  boolean useTimebank = false;
+    private boolean useTimebank = false;
     private int timebank = 0;
     private boolean timelimitExceededLastTurn = false;
     private final int MAX_SOFT_TIMELIMIT_EXCEEDS = 2;
@@ -116,6 +116,35 @@ abstract public class AbstractPlayer {
     }
 
     /**
+     * Get the execution time of the last successful execution
+     * Will still return the previous value in case of a timeout
+     *
+     * @return The execution time of the last execution in milliseconds
+     */
+    public long getLastExectionTimeMs() {
+        return lastExecutionTimeMs;
+    }
+
+    /**
+     * Get how often the player has already exceeded the time limit in this game
+     *
+     * @return how often the player has already exceeded the time limit in this game
+     */
+    public int getTimelimitsExceeded() {
+        return timelimitsExceeded;
+    }
+
+    /**
+     * Get whether the player exceeded the time limit in the last turn
+     *
+     * @return true, if the player exceeded the time limit in the last turn
+     */
+    public boolean hasTimelimitExceededLastTurn() {
+        return timelimitExceededLastTurn;
+    }
+
+
+    /**
      * Adds a new line to the input to send to the player on execute.
      * 
      * @param line
@@ -138,7 +167,10 @@ abstract public class AbstractPlayer {
         gameManagerProvider.get().execute(this);
         this.hasBeenExecuted = true;
         this.hasNeverBeenExecuted = false;
-        if (this.useTimebank) this.timebank -= getLastExectionTimeMs();
+        if (this.useTimebank) {
+            if (hasTimedOut()) this.timebank = 0;
+            else this.timebank -= getLastExectionTimeMs();
+        }
         this.timelimitExceededLastTurn = getLastExectionTimeMs() > this.timelimit;
         if (this.timelimitExceededLastTurn) this.timelimitsExceeded++;
         if (this.timelimitsExceeded > MAX_SOFT_TIMELIMIT_EXCEEDS) this.timeout = true;
@@ -218,17 +250,5 @@ abstract public class AbstractPlayer {
 
     final public void setLastExecutionTimeMs(long ms) {
         this.lastExecutionTimeMs = ms;
-    }
-    
-    public long getLastExectionTimeMs() {
-        return lastExecutionTimeMs;
-    }
-
-    public int getTimelimitsExceeded() {
-        return timelimitsExceeded;
-    }
-
-    public boolean hasTimelimitExceededLastTurn() {
-        return timelimitExceededLastTurn;
     }
 }

--- a/engine/core/src/main/java/com/codingame/gameengine/core/GameManager.java
+++ b/engine/core/src/main/java/com/codingame/gameengine/core/GameManager.java
@@ -39,6 +39,7 @@ abstract public class GameManager<T extends AbstractPlayer> {
     private static final int GAME_DURATION_SOFT_QUOTA = 25_000;
     private static final int MAX_TURN_TIME = GAME_DURATION_SOFT_QUOTA;
     private static final int MIN_TURN_TIME = 50;
+    private static final int SOFT_TIMELIMIT_EXTRA = 50;
 
     protected List<T> players;
     private int maxTurns = 200;
@@ -196,7 +197,9 @@ abstract public class GameManager<T extends AbstractPlayer> {
             if (nbrOutputLines > 0) {
                 addTurnTime();
             }
-            dumpNextPlayerInfos(player.getIndex(), nbrOutputLines, player.hasNeverBeenExecuted() ? firstTurnMaxTime : turnMaxTime);
+            int timelimit = player.hasNeverBeenExecuted() ? firstTurnMaxTime : turnMaxTime;
+            player.setTimelimit(timelimit);
+            dumpNextPlayerInfos(player.getIndex(), nbrOutputLines, timelimit + SOFT_TIMELIMIT_EXTRA);
 
             // READ PLAYER OUTPUTS
             iCmd = InputCommand.parse(s.nextLine());

--- a/engine/core/src/main/java/com/codingame/gameengine/core/GameManager.java
+++ b/engine/core/src/main/java/com/codingame/gameengine/core/GameManager.java
@@ -453,7 +453,7 @@ abstract public class GameManager<T extends AbstractPlayer> {
      * @param timebank
      *              Duration in milliseconds
      * @throws IllegalArgumentException
-     *             if timebank &lt; 1000 or &gt; 25000
+     *             if timebank &lt; 1000 or &gt; 30000 for all players combined
      */
     public void setTimebank(int timebank) {
         if (useTurntime) {

--- a/engine/core/src/main/java/com/codingame/gameengine/core/GameManager.java
+++ b/engine/core/src/main/java/com/codingame/gameengine/core/GameManager.java
@@ -523,7 +523,7 @@ abstract public class GameManager<T extends AbstractPlayer> {
      *             if firstTurnMaxTime &lt; 50 or &gt; 25000
      */
     public void setFirstTurnMaxTime(int firstTurnMaxTime) throws IllegalArgumentException {
-        if (useTurntime) {
+        if (useTimebank) {
             throw new UnsupportedOperationException("Use either setTimebank or setTurnMaxTime & setFirstTurnMaxTime, not both");
         } else if (firstTurnMaxTime < MIN_TURN_TIME) {
             throw new IllegalArgumentException("Invalid turn max time : stay above 50ms");

--- a/engine/core/src/main/java/com/codingame/gameengine/core/GameManager.java
+++ b/engine/core/src/main/java/com/codingame/gameengine/core/GameManager.java
@@ -74,6 +74,8 @@ abstract public class GameManager<T extends AbstractPlayer> {
     private int totalViewDataBytesSent = 0;
     private int totalGameSummaryBytes = 0;
     private int totalTurnTime = 0;
+    private boolean useTurntime = false;
+    private boolean useTimebank = false;
 
     private boolean viewWarning, summaryWarning;
     private boolean monitoringRequested;
@@ -194,12 +196,13 @@ abstract public class GameManager<T extends AbstractPlayer> {
             }
             dumpInfos();
             dumpNextPlayerInput(player.getInputs().toArray(new String[0]));
-            if (nbrOutputLines > 0) {
+            if (nbrOutputLines > 0 && !useTimebank) {
                 addTurnTime();
             }
             int timelimit = player.hasNeverBeenExecuted() ? firstTurnMaxTime : turnMaxTime;
+            if (useTimebank) timelimit = player.getRemainingTimebank();
             player.setTimelimit(timelimit);
-            dumpNextPlayerInfos(player.getIndex(), nbrOutputLines, timelimit + SOFT_TIMELIMIT_EXTRA);
+            dumpNextPlayerInfos(player.getIndex(), nbrOutputLines, timelimit + (useTimebank ? 0 : SOFT_TIMELIMIT_EXTRA));
 
             // READ PLAYER OUTPUTS
             iCmd = InputCommand.parse(s.nextLine());
@@ -445,6 +448,29 @@ abstract public class GameManager<T extends AbstractPlayer> {
     }
 
     /**
+     * Set the timeout delay for each player for the whole game. This will disable the time limit per turn
+     *
+     * @param timebank
+     *              Duration in milliseconds
+     * @throws IllegalArgumentException
+     *             if timebank &lt; 1000 or &gt; 25000
+     */
+    public void setTimebank(int timebank) {
+        if (useTurntime) {
+            throw new UnsupportedOperationException("Use either setTimebank or setTurnMaxTime & setFirstTurnMaxTime, not both");
+        } else if (timebank < MIN_TURN_TIME) {
+            throw new IllegalArgumentException("Invalid time bank: use at least 1000ms");
+        } else if (timebank * players.size() > GAME_DURATION_HARD_QUOTA) {
+            throw new IllegalArgumentException("Invalid timebank: stay under " + GAME_DURATION_HARD_QUOTA + "ms total, " + (GAME_DURATION_HARD_QUOTA / players.size()) + " per player");
+        }
+        totalTurnTime += timebank * players.size();
+        this.useTimebank = true;
+        for (T player : players) {
+            player.setTimebank(timebank);
+        }
+    }
+
+    /**
      * Set the maximum amount of turns. Default: 400.
      * 
      * @param maxTurns
@@ -477,12 +503,15 @@ abstract public class GameManager<T extends AbstractPlayer> {
      *             if turnMaxTime &lt; 50 or &gt; 25000
      */
     public void setTurnMaxTime(int turnMaxTime) throws IllegalArgumentException {
-        if (turnMaxTime < MIN_TURN_TIME) {
+        if (useTimebank) {
+            throw new UnsupportedOperationException("Use either setTimebank or setTurnMaxTime & setFirstTurnMaxTime, not both");
+        } else if (turnMaxTime < MIN_TURN_TIME) {
             throw new IllegalArgumentException("Invalid turn max time : stay above 50ms");
         } else if (turnMaxTime > MAX_TURN_TIME) {
             throw new IllegalArgumentException("Invalid turn max time : stay under 25s");
         }
         this.turnMaxTime = turnMaxTime;
+        this.useTurntime = true;
     }
 
     /**
@@ -494,12 +523,15 @@ abstract public class GameManager<T extends AbstractPlayer> {
      *             if firstTurnMaxTime &lt; 50 or &gt; 25000
      */
     public void setFirstTurnMaxTime(int firstTurnMaxTime) throws IllegalArgumentException {
-        if (firstTurnMaxTime < MIN_TURN_TIME) {
+        if (useTurntime) {
+            throw new UnsupportedOperationException("Use either setTimebank or setTurnMaxTime & setFirstTurnMaxTime, not both");
+        } else if (firstTurnMaxTime < MIN_TURN_TIME) {
             throw new IllegalArgumentException("Invalid turn max time : stay above 50ms");
         } else if (firstTurnMaxTime > MAX_TURN_TIME) {
             throw new IllegalArgumentException("Invalid turn max time : stay under 25s");
         }
         this.firstTurnMaxTime = firstTurnMaxTime;
+        this.useTurntime = true;
     }
 
     /**


### PR DESCRIPTION
In the recent contest we saw a high timeout rate, especially when the servers were busy on league opening, in the last hours of the contest and and the final rerun. This affected a lot of players even at the top of legend, so it seems to be a platform issue rather than players suddenly forgetting how to measure time. The contestant programs just get a random delay, sometimes 20 milliseconds long - and they lose the game because of it.
<img width="728" height="101" alt="image" src="https://github.com/user-attachments/assets/ffa635ae-0c53-461c-a82b-4d0f8abcd1ab" />
<img width="335" height="83" alt="image" src="https://github.com/user-attachments/assets/7381555f-5a57-48c8-bda4-44c5dbb5b22e" />
<img width="244" height="83" alt="image" src="https://github.com/user-attachments/assets/2bbc5439-2c1f-4af3-b5b0-3be3f114305c" />

I understand that it's hard to prevent the server from doing any other tasks that affect program performance for contestants.
This commit is one suggestion to at least reduce the consequences of such a random delay by modifying the existing behaviour and introducing a new one.
### Turn-based timing with 3-strikes rule
It lets each program run for an extra 50 milliseconds, but also checks if those extra 50ms were necessary. If they weren't, all is fine. Otherwise it counts as one strike, violating the time limit. If a bot exceeds the limit 3 times in the same match, it gets eliminated with a regular timeout exception. If even the additional 50ms don't help, the player can also get eliminated immediately.
Test link: https://www.codingame.com/ide/demo/1455013cb304fa9512c0f8525f73702f6e4a0c4
### Timebank
Instead of setting a limit for each turn, the players get a time limit for the whole game. They can freely choose to use more time in one turn and less in another. This way a random delay won't be as punishing.
Test link: https://www.codingame.com/ide/demo/1455539e9339ee30ac7742e9204900bb7877948
*note the changed input protocol, the remaining timebank is the first turn input, before powerSourceCount*
### Usage of those features
The game creator decides, if they want to use the classic per-turn way or the new timebank.
For the classic way no changes to the referee are needed, it will just work. For the timebank there has to be a call to `setTimebank`, e.g. `gameManager.setTimebank(10000);`. When setting the timebank, it's not allowed to also call `setTurnMaxTime`.