### PR TITLE
Modernize agent I/O with CompletableFuture and BufferedReader.

### DIFF
--- a/runner/src/main/java/com/codingame/gameengine/runner/Agent.java
+++ b/runner/src/main/java/com/codingame/gameengine/runner/Agent.java
@@ -1,10 +1,16 @@
 package com.codingame.gameengine.runner;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -15,34 +21,45 @@ abstract class Agent {
     public static final int AGENT_MAX_BUFFER_SIZE = 10_000;
     public static final int THRESHOLD_LIMIT_STDERR_SIZE = 4096 * 50;
 
+    /**
+     * Single dedicated thread for all blocking agent I/O — sequential game loop
+     * never needs more than one.
+     */
+    private static final ExecutorService AGENT_IO_EXECUTOR = Executors.newSingleThreadExecutor(r -> {
+        Thread t = new Thread(r, "agent-reader");
+        t.setDaemon(true);
+        return t;
+    });
+
     private static Log log = LogFactory.getLog(Agent.class);
 
     private OutputStream processStdin;
-    private InputStream processStdout;
+    private BufferedReader processStdoutReader;
     private InputStream processStderr;
     private int totalStderrBytesSent = 0;
     private int agentId;
-    private boolean lastAgentByteIsCarriageReturn = false;
     private boolean failed = false;
 
     private String nickname;
     private String avatar;
 
     public long lastExecutionTimeMs;
+
     public Agent() {
     }
 
     abstract protected OutputStream getInputStream();
 
-    abstract protected InputStream getOutputStream();
+    abstract protected BufferedReader getOutputReader();
 
     abstract protected InputStream getErrorStream();
 
     /**
-     * Initialize an agent given global properties. A call to this function is needed before-all
+     * Initialize an agent given global properties. A call to this function is
+     * needed before-all
      *
      * @param conf
-     *            Global configuration
+     *             Global configuration
      */
     public void initialize(Properties conf) {
         this.lastExecutionTimeMs = 0;
@@ -54,7 +71,7 @@ abstract class Agent {
     public void execute() {
         try {
             this.processStdin = getInputStream();
-            this.processStdout = getOutputStream();
+            this.processStdoutReader = getOutputReader();
             this.processStderr = getErrorStream();
             runInputOutput();
         } catch (Exception e) {
@@ -70,7 +87,7 @@ abstract class Agent {
      * Launch the agent. After the call, agent is ready to process input / output
      *
      * @throws Exception
-     *             if an error occurs
+     *                   if an error occurs
      */
     protected abstract void runInputOutput() throws Exception;
 
@@ -78,7 +95,7 @@ abstract class Agent {
      * Write 'input' to standard input of agent
      *
      * @param input
-     *            an input to write
+     *              an input to write
      */
     public void sendInput(String input) {
         if (processStdin != null) {
@@ -98,57 +115,56 @@ abstract class Agent {
      * Get the output of an agent
      *
      * @param nbLine
-     *            Number of lines wanted
+     *                Number of lines wanted
      * @param timeout
-     *            Stop reading after timeout milliseconds
-     * @return the agent output
+     *                Stop reading after timeout milliseconds
+     * @return the agent output, or null if timed out or reader closed
      */
     public String getOutput(int nbLine, long timeout) {
-        if (processStdout == null) {
+        return getOutput(nbLine, timeout, AGENT_MAX_BUFFER_SIZE);
+    }
+
+    /**
+     * Read at most maxOutputSize bytes across nbLine lines.
+     * 
+     * @param nbLine
+     *                      Number of lines wanted
+     * @param timeout
+     *                      Stop reading after timeout milliseconds
+     * @param maxOutputSize
+     *                      Maximum number of bytes to read
+     * @return the agent output, or null if timed out or reader closed
+     */
+    protected final String getOutput(int nbLine, long timeout, int maxOutputSize) {
+        if (processStdoutReader == null) {
             return null;
         }
 
-        try {
-            byte[] tmp = new byte[AGENT_MAX_BUFFER_SIZE];
-            int offset = 0;
-            int nbOccurences = 0;
-
-            long t0 = System.nanoTime();
-
-            while ((offset < AGENT_MAX_BUFFER_SIZE) && (nbOccurences < nbLine)) {
-                long current = System.nanoTime();
-                if ((current - t0) > (timeout * 1_000_000l)) {
-                    break;
-                }
-
-                if (processStdout.available() > 0) {
-                    int nbRead = processStdout.read(tmp, offset, 1);
-                    if (nbRead < 0) {
-                        // Should not happen, just in case...
+        CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> {
+            try {
+                StringBuilder sb = new StringBuilder();
+                for (int i = 0; i < nbLine; i++) {
+                    String line = processStdoutReader.readLine();
+                    if (line == null) {
                         break;
                     }
-                    byte curByte = tmp[offset];
-                    if (!((curByte == '\n') && lastAgentByteIsCarriageReturn)) {
-                        offset += nbRead;
-                        if ((curByte == '\n') || (curByte == '\r')) {
-                            ++nbOccurences;
-                        }
-                    }
-                    lastAgentByteIsCarriageReturn = curByte == '\r';
-                } else {
-                    if ((offset < AGENT_MAX_BUFFER_SIZE) && (nbOccurences < nbLine)) {
-                        Thread.sleep(1);
+                    sb.append(line).append('\n');
+                    if (sb.length() >= maxOutputSize) {
+                        break;
                     }
                 }
+                return sb.toString();
+            } catch (IOException e) {
+                return null;
             }
+        }, AGENT_IO_EXECUTOR);
 
-            return new String(tmp, 0, offset, UTF8);
-        } catch (IOException e1) {
-            processStdout = null;
-        } catch (InterruptedException e) {
-            // wtf
+        try {
+            return future.orTimeout(timeout, TimeUnit.MILLISECONDS).join();
+        } catch (CompletionException e) {
+            future.cancel(true);
+            return null;
         }
-        return null;
     }
 
     /**

--- a/runner/src/main/java/com/codingame/gameengine/runner/CommandLinePlayerAgent.java
+++ b/runner/src/main/java/com/codingame/gameengine/runner/CommandLinePlayerAgent.java
@@ -1,17 +1,19 @@
 package com.codingame.gameengine.runner;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Properties;
 
 /**
- * This class is used in with the <code>GameRunner</code> to add an AI as a player.
+ * This class is used in with the <code>GameRunner</code> to add an AI as a
+ * player.
  */
 public class CommandLinePlayerAgent extends Agent {
 
     private OutputStream processStdin;
-    private InputStream processStdout;
+    private BufferedReader processInputReader;
     private InputStream processStderr;
     private String[] commandArray;
     private Process process;
@@ -20,18 +22,18 @@ public class CommandLinePlayerAgent extends Agent {
      * Creates an Agent for your game, will run the given commandLine at game start
      * 
      * @param commandLine
-     *            the command line to run
+     *                    the command line to run
      */
     public CommandLinePlayerAgent(String commandLine) {
         super();
         this.commandArray = commandLine.split(" ");
     }
-    
+
     /**
      * Creates an Agent for your game, will run the given commandLine at game start
      * 
      * @param commandArray
-     *            the command array to run
+     *                     the command array to run
      */
     public CommandLinePlayerAgent(String[] commandArray) {
         super();
@@ -44,8 +46,8 @@ public class CommandLinePlayerAgent extends Agent {
     }
 
     @Override
-    protected InputStream getOutputStream() {
-        return processStdout;
+    protected BufferedReader getOutputReader() {
+        return processInputReader;
     }
 
     @Override
@@ -61,21 +63,15 @@ public class CommandLinePlayerAgent extends Agent {
             throw new RuntimeException("Failed to launch " + String.join(" ", commandArray), e);
         }
         processStdin = process.getOutputStream();
-        processStdout = process.getInputStream();
+        processInputReader = process.inputReader();
         processStderr = process.getErrorStream();
-    }
-
-    @Override
-    public String getOutput(int nbLine, long timeout) {
-        String output = super.getOutput(nbLine, timeout);
-        return output;
     }
 
     /**
      * Launch the agent. After the call, agent is ready to process input / output
      * 
      * @throws Exception
-     *             if an error occurs
+     *                   if an error occurs
      */
 
     @Override

--- a/runner/src/main/java/com/codingame/gameengine/runner/JavaPlayerAgent.java
+++ b/runner/src/main/java/com/codingame/gameengine/runner/JavaPlayerAgent.java
@@ -1,7 +1,9 @@
 package com.codingame.gameengine.runner;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
@@ -34,11 +36,12 @@ public class JavaPlayerAgent extends Agent {
 
     private OutputStream processStdin;
     private InputStream processStdout;
+    private BufferedReader processStdoutReader;
     private InputStream processStderr;
 
     /**
      * @param className
-     *            The name of the class to use as a participating AI.
+     *                  The name of the class to use as a participating AI.
      */
     public JavaPlayerAgent(String className) {
         super();
@@ -48,6 +51,7 @@ public class JavaPlayerAgent extends Agent {
         try {
             processStdin = new PipedOutputStream(agentStdin);
             processStdout = new PipedInputStream(agentStdout, 100_000);
+            processStdoutReader = new BufferedReader(new InputStreamReader(processStdout, UTF8));
             processStderr = new PipedInputStream(agentStderr, 100_000);
         } catch (IOException e) {
             throw new RuntimeException("Cannot initialize Player Agent", e);
@@ -60,8 +64,8 @@ public class JavaPlayerAgent extends Agent {
     }
 
     @Override
-    protected InputStream getOutputStream() {
-        return processStdout;
+    protected BufferedReader getOutputReader() {
+        return processStdoutReader;
     }
 
     @Override
@@ -77,7 +81,7 @@ public class JavaPlayerAgent extends Agent {
      * Launch the agent. After the call, agent is ready to process input / output
      * 
      * @throws Exception
-     *             if an error occurs
+     *                   if an error occurs
      */
     @Override
     protected void runInputOutput() throws Exception {
@@ -99,7 +103,7 @@ public class JavaPlayerAgent extends Agent {
             if (javaRunnerThread.isAlive()) {
                 // TODO
                 javaRunnerThread.interrupt();
-//                 javaRunnerThread.destroy();
+                // javaRunnerThread.destroy();
                 javaRunnerThread.stop();
             }
         }

--- a/runner/src/main/java/com/codingame/gameengine/runner/RefereeAgent.java
+++ b/runner/src/main/java/com/codingame/gameengine/runner/RefereeAgent.java
@@ -1,7 +1,9 @@
 package com.codingame.gameengine.runner;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
@@ -13,7 +15,6 @@ class RefereeAgent extends Agent {
 
     public static final int REFEREE_MAX_BUFFER_SIZE_EXTRA = 100_000;
     public static final int REFEREE_MAX_BUFFER_SIZE = 30_000;
-    private boolean lastRefereeByteIsCarriageReturn = false;
 
     private PipedInputStream agentStdin = new PipedInputStream(100_000);
     private PipedOutputStream agentStdout = new PipedOutputStream();
@@ -21,8 +22,9 @@ class RefereeAgent extends Agent {
 
     private OutputStream processStdin = null;
     private InputStream processStdout = null;
+    private BufferedReader processStdoutReader;
     private InputStream processStderr = null;
-    
+
     private Thread thread;
 
     public RefereeAgent() {
@@ -31,12 +33,13 @@ class RefereeAgent extends Agent {
         try {
             processStdin = new PipedOutputStream(agentStdin);
             processStdout = new PipedInputStream(agentStdout, 100_000);
+            processStdoutReader = new BufferedReader(new InputStreamReader(processStdout, UTF8));
             processStderr = new PipedInputStream(agentStderr, 100_000);
         } catch (IOException e) {
             throw new RuntimeException("Cannot initialize Referee Agent");
         }
     }
-    
+
     @Override
     public void destroy() {
         if (thread != null) {
@@ -44,15 +47,14 @@ class RefereeAgent extends Agent {
         }
     }
 
-
     @Override
     protected OutputStream getInputStream() {
         return processStdin;
     }
 
     @Override
-    protected InputStream getOutputStream() {
-        return processStdout;
+    protected BufferedReader getOutputReader() {
+        return processStdoutReader;
     }
 
     @Override
@@ -78,58 +80,7 @@ class RefereeAgent extends Agent {
 
     @Override
     public String getOutput(int nbLine, long timeout, boolean extraBufferSpace) {
-        if (processStdout == null) {
-            return null;
-        }
-        int maxBufferSize = extraBufferSpace ? REFEREE_MAX_BUFFER_SIZE_EXTRA : REFEREE_MAX_BUFFER_SIZE;
-        try {
-            byte[] tmp = new byte[maxBufferSize];
-            int offset = 0;
-            int nbOccurences = 0;
-
-            long t0 = System.nanoTime();
-
-            while ((offset < maxBufferSize) && (nbOccurences < nbLine)) {
-                long current = System.nanoTime();
-                if ((current - t0) > (timeout * 1_000_000L)) {
-                    break;
-                }
-
-                while ((offset < maxBufferSize) && (processStdout.available() > 0)
-                        && (nbOccurences < nbLine)) {
-                    current = System.nanoTime();
-                    if ((current - t0) > (timeout * 1_000_000L)) {
-                        break;
-                    }
-
-                    int nbRead = processStdout.read(tmp, offset, 1);
-                    if (nbRead <= 0) {
-                        break;
-                    }
-                    byte curByte = tmp[offset];
-                    if (!((curByte == '\n') && lastRefereeByteIsCarriageReturn)) {
-                        offset += nbRead;
-                        if ((curByte == '\n') || (curByte == '\r')) {
-                            ++nbOccurences;
-                        }
-                    }
-                    lastRefereeByteIsCarriageReturn = curByte == '\r';
-                }
-
-                if (!((offset < REFEREE_MAX_BUFFER_SIZE) && (nbOccurences < nbLine))) {
-                    break;
-                }
-
-                try {
-                    Thread.sleep(1);
-                } catch (Exception e) {
-                }
-            }
-            return new String(tmp, 0, offset, UTF8);
-        } catch (IOException e) {
-            e.printStackTrace();
-            processStdout = null;
-        }
-        return null;
+        int limit = extraBufferSpace ? REFEREE_MAX_BUFFER_SIZE_EXTRA : REFEREE_MAX_BUFFER_SIZE;
+        return getOutput(nbLine, timeout, limit);
     }
 }


### PR DESCRIPTION
## Motivation

During the last contest we observed a **high timeout rate**, especially during league openings, the final stretch, and the rerun. Players at the top of Legend got eliminated by timeouts that were clearly caused by platform load rather than their own code.

One likely contributor is the polling loop in `RefereeAgent.getOutput()`, which used **`InputStream.available()`** to check whether data was ready to read, sleeping 1 ms between checks. `available()` only returns bytes already in the kernel buffer — it is not aware of bytes that are in transit or buffered elsewhere. Under server load, this may cause the loop to spin past the timeout deadline even when the bot had already responded in time, producing spurious timeouts.

See also: https://github.com/CodinGame/codingame-game-engine/pull/78 (soft-timeout approach tackling the same problem).

## Changes

- **Non-blocking timeouts via `CompletableFuture.orTimeout`** — replaces the `available()` busy-wait loop with a blocking `BufferedReader.readLine()` offloaded to a dedicated I/O thread. The future times out precisely after `timeout` ms regardless of server load.
- **Dedicated `ExecutorService` (`AGENT_IO_EXECUTOR`)** — a single daemon thread handles all blocking reads, avoiding `ForkJoinPool` starvation that `CompletableFuture.supplyAsync` with the common pool would risk.
- **`BufferedReader` instead of raw [InputStream](cci:1://file:///home/domiko/Documents/CodinGame/codingame-game-engine/runner/src/main/java/com/codingame/gameengine/runner/CommandLinePlayerAgent.java:42:4-45:5) byte-reads** — simpler line-based reading replaces the manual byte-by-byte loop with CR/LF bookkeeping.
- **Removed `processStdout` / `getOutputStream()`** — the raw [InputStream](cci:1://file:///home/domiko/Documents/CodinGame/codingame-game-engine/runner/src/main/java/com/codingame/gameengine/runner/CommandLinePlayerAgent.java:42:4-45:5) field is no longer needed; only the `BufferedReader` is used.
- **Deduplicated `RefereeAgent.getOutput()`** — ~50 lines of duplicated timing logic removed; now delegates to `Agent.getOutput()` with the appropriate buffer size limit.