### PR TITLE
SpriteAnimation: introduce imageRange

### DIFF
--- a/engine/modules/entities/src/main/java/com/codingame/gameengine/module/entities/Serializer.java
+++ b/engine/modules/entities/src/main/java/com/codingame/gameengine/module/entities/Serializer.java
@@ -60,6 +60,7 @@ class Serializer {
         keys.put("zIndex", "z");
         keys.put("blendMode", "b");
         keys.put("images", "I");
+        keys.put("imageRange", "IR");
         keys.put("restarted", "rs");
         keys.put("playing", "p");
         keys.put("loop", "l");

--- a/engine/modules/entities/src/main/java/com/codingame/gameengine/module/entities/SpriteAnimation.java
+++ b/engine/modules/entities/src/main/java/com/codingame/gameengine/module/entities/SpriteAnimation.java
@@ -1,5 +1,6 @@
 package com.codingame.gameengine.module.entities;
 
+import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -169,7 +170,9 @@ public class SpriteAnimation extends TextureBasedEntity<SpriteAnimation> impleme
             throw new IllegalArgumentException("Animation must contain at least 1 image.");
         }
         this.images = images;
-        set("images", Stream.of(images).collect(Collectors.joining(",")), null);
+        String[] compressed = compressImages();
+        if (compressed == images) set("images", Stream.of(images).collect(Collectors.joining(",")), null);
+        else set("imageRange", compressed[0], null);
         return this;
     }
 
@@ -179,6 +182,31 @@ public class SpriteAnimation extends TextureBasedEntity<SpriteAnimation> impleme
      * @return the names of the images used for this animation.
      */
     public String[] getImages() {
+        return images;
+    }
+
+    private String[] compressImages() {
+        if (Stream.of(images).anyMatch(i -> i.contains("|"))) return images;
+        String uncompressed = Stream.of(images).collect(Collectors.joining(","));
+        for (int prefixLength = images[0].length() - 1; prefixLength > 0; prefixLength--) {
+            String prefix = images[0].substring(0, prefixLength);
+            String numberText = images[0].substring(prefixLength);
+            int start = 0;
+            try {
+                start = Integer.parseInt(numberText);
+            } catch (NumberFormatException ex) {
+                break; // can't parse, no compression possible
+            }
+            boolean validPrefix = true;
+            for (int i = 1; i < images.length; i++) {
+                String suffix = String.format("%0" + numberText.length() + "d", start + i); // add leading zeros
+                if (!images[i].equals(prefix + suffix)) validPrefix = false;
+            }
+            if (!validPrefix) continue;
+            String compressed = prefix + "|" + numberText + "|" + images[images.length - 1].substring(prefixLength);
+            if (compressed.length() < uncompressed.length())
+                return new String[]{compressed};
+        }
         return images;
     }
 }

--- a/engine/modules/entities/src/main/java/com/codingame/gameengine/module/entities/SpriteAnimation.java
+++ b/engine/modules/entities/src/main/java/com/codingame/gameengine/module/entities/SpriteAnimation.java
@@ -171,8 +171,14 @@ public class SpriteAnimation extends TextureBasedEntity<SpriteAnimation> impleme
         }
         this.images = images;
         String[] compressed = compressImages();
-        if (compressed == images) set("images", Stream.of(images).collect(Collectors.joining(",")), null);
-        else set("imageRange", compressed[0], null);
+        if (compressed == images) {
+            set("images", Stream.of(images).collect(Collectors.joining(",")), null);
+            set("imageRange", "");
+        }
+        else {
+            set("images", "");
+            set("imageRange", compressed[0], null);
+        }
         return this;
     }
 

--- a/engine/modules/entities/src/main/resources/view/entity-module/Command.js
+++ b/engine/modules/entities/src/main/resources/view/entity-module/Command.js
@@ -38,6 +38,7 @@ const PROPERTY_KEY_MAP = {
   z: 'zIndex',
   b: 'blendMode',
   I: 'images',
+  IR: 'imageRange',
   rs: 'restarted',
   p: 'playing',
   l: 'loop',

--- a/engine/modules/entities/src/main/resources/view/entity-module/SpriteAnimation.js
+++ b/engine/modules/entities/src/main/resources/view/entity-module/SpriteAnimation.js
@@ -10,6 +10,7 @@ export class SpriteAnimation extends TextureBasedEntity {
     super()
     Object.assign(this.defaultState, {
       images: '',
+      imageRange: '',
       loop: false,
       duration: 1000,
       playing: true,
@@ -33,6 +34,20 @@ export class SpriteAnimation extends TextureBasedEntity {
 
   updateDisplay (state, changed, globalData, frame, progress) {
     super.updateDisplay(state, changed, globalData)
+
+    if (state.imageRange) {
+      let parts = state.imageRange.split('|')
+      let prefix = parts[0]
+      let startText = parts[1]
+      let lastImage = prefix + parts[2]
+      let images = [prefix + startText]
+      for (let i = 1; images[images.length - 1] !== lastImage; i++) {
+        let suffix = `${+startText + i}`
+        while (suffix.length < startText.length) suffix = '0' + suffix
+        images.push(prefix + suffix)
+      }
+      state.images = images.join(',')
+    }
 
     if (state.images) {
       const images = state.images.split(',')

--- a/engine/modules/entities/src/main/resources/view/entity-module/properties.js
+++ b/engine/modules/entities/src/main/resources/view/entity-module/properties.js
@@ -77,6 +77,7 @@ export const PROPERTIES = {
   baseHeight: constOpts,
   image: stringOpts,
   images: stringOpts,
+  imageRange: stringOpts,
   scaleMode: stringOpts,
   restarted: {
     type: String,


### PR DESCRIPTION
`SpriteAnimation.setImages` can be quite expensive, as it serializes the whole image sequence. When the animation sequences changes to something else and then changes back (because a character plays an attack animation, changes moving direction, ...), the whole sequence gets serialized again.
There is the AnimationModule as an alternative, but it's not as easy to use.

Here is an example from [Code Keeper](https://www.codingame.com/replay/877083351) - not even quoting a full frame:
12 0 I c5o12,c5o13,c5o14,c5o15,c5o16,c5o17,c5o18,c5o19,c5o20,c5o21,c5o22,c5o23;1210 0 I c4i21,c4i22,c4i23,c4i24,c4i25,c4i26,c4i27,c4i28,c4i29,c4i30,c4i31,c4i32,c4i33,c4i34,c4i35,c4i36,c4i37,c4i38,c4i39,c4i40,c4i41;1213 0 I c4i21,c4i22,c4i23,c4i24,c4i25,c4i26,c4i27,c4i28,c4i29,c4i30,c4i31,c4i32,c4i33,c4i34,c4i35,c4i36,c4i37,c4i38,c4i39,c4i40,c4i41;

While image names don't have to be in sequence, they are in most scenarios. So it's possible to compress them by just storing the prefix, the first and last suffix.
E.g. `I c5o12,c5o13,c5o14,c5o15,c5o16,c5o17,c5o18,c5o19,c5o20,c5o21,c5o22,c5o23` would become `IR c5o|12|23` with this commit.

It checks, if image names are in sequence. If they are, the new `imageRange` property is used to serialize and deserialize. Otherwise the old `images` is still used as a fallback solution.
From a user perspective nothing changes, this all happens behind the scenes.